### PR TITLE
Add in-memory trading and accounting backend MVP

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "bundle": "bun build app.js --outdir=dist --target=node --minify",
     "server": "bun --hot --no-clear-screen app.js",
-    "preview": "bun app.js"
+    "preview": "bun app.js",
+    "test": "bun test"
   },
   "dependencies": {
     "@prisma/client": "^6.16.2",

--- a/server/routes/accountRoutes.js
+++ b/server/routes/accountRoutes.js
@@ -1,0 +1,62 @@
+import express from 'express'
+import {
+  createAccount,
+  createTransaction,
+  getAccountById,
+  listAccounts,
+  listBalances,
+  listLedgerEntries,
+  listTransactions,
+} from '../services/accountingEngine.js'
+import { listAuditLogs } from '../services/dataStore.js'
+
+const router = express.Router()
+
+router.post('/accounts', (req, res) => {
+  try {
+    const account = createAccount(req.body)
+    res.status(201).json(account)
+  } catch (error) {
+    res.status(400).json({ message: error.message })
+  }
+})
+
+router.get('/accounts', (req, res) => {
+  res.json(listAccounts())
+})
+
+router.get('/accounts/:id', (req, res) => {
+  const account = getAccountById(req.params.id)
+  if (!account) {
+    res.status(404).json({ message: 'Account not found' })
+    return
+  }
+  res.json(account)
+})
+
+router.get('/balances', (req, res) => {
+  res.json(listBalances(req.query.accountId))
+})
+
+router.get('/ledger', (req, res) => {
+  res.json(listLedgerEntries(req.query.accountId))
+})
+
+router.post('/transactions', (req, res) => {
+  try {
+    const transaction = createTransaction(req.body)
+    res.status(201).json(transaction)
+  } catch (error) {
+    res.status(400).json({ message: error.message })
+  }
+})
+
+router.get('/transactions', (req, res) => {
+  res.json(listTransactions(req.query.accountId))
+})
+
+router.get('/audit-logs', (req, res) => {
+  res.json(listAuditLogs())
+})
+
+export default router

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -1,6 +1,16 @@
 import express from 'express'
 import authRoutes from './authRoutes.js'
+import tradingRoutes from './tradingRoutes.js'
+import accountRoutes from './accountRoutes.js'
+
 const router = express.Router()
+
 router.use('/api/auth', authRoutes)
+router.use('/api', tradingRoutes)
+router.use('/api', accountRoutes)
+
+router.get('/health', (_req, res) => {
+  res.json({ status: 'ok' })
+})
 
 export default router

--- a/server/routes/tradingRoutes.js
+++ b/server/routes/tradingRoutes.js
@@ -1,0 +1,62 @@
+import express from 'express'
+import {
+  cancelOrder,
+  getOrderById,
+  getQuote,
+  listExecutions,
+  listOrders,
+  listPositions,
+  listQuotes,
+  placeOrder,
+} from '../services/tradingEngine.js'
+
+const router = express.Router()
+
+router.post('/orders', (req, res) => {
+  try {
+    const { order, executions } = placeOrder(req.body)
+    res.status(201).json({ order, executions })
+  } catch (error) {
+    res.status(400).json({ message: error.message })
+  }
+})
+
+router.get('/orders', (req, res) => {
+  res.json(listOrders())
+})
+
+router.get('/orders/:id', (req, res) => {
+  const order = getOrderById(req.params.id)
+  if (!order) {
+    res.status(404).json({ message: 'Order not found' })
+    return
+  }
+  res.json(order)
+})
+
+router.delete('/orders/:id', (req, res) => {
+  try {
+    const order = cancelOrder(req.params.id)
+    res.json(order)
+  } catch (error) {
+    res.status(400).json({ message: error.message })
+  }
+})
+
+router.get('/executions', (req, res) => {
+  res.json(listExecutions())
+})
+
+router.get('/positions', (req, res) => {
+  res.json(listPositions(req.query.accountId))
+})
+
+router.get('/quotes', (req, res) => {
+  res.json(listQuotes())
+})
+
+router.get('/quotes/:instrumentId', (req, res) => {
+  res.json(getQuote(req.params.instrumentId))
+})
+
+export default router

--- a/server/services/accountingEngine.js
+++ b/server/services/accountingEngine.js
@@ -1,0 +1,232 @@
+import { randomUUID } from 'crypto'
+import {
+  ACTION_TYPES,
+  ACTOR_TYPES,
+  LEDGER_ENTRY_TYPES,
+  OBJECT_TYPES,
+  TRANSACTION_STATUSES,
+  TRANSACTION_TYPES,
+  getState,
+  recordAuditLog,
+} from './dataStore.js'
+
+function findAccount(accountId) {
+  return getState().accounts.find((account) => account.id === accountId)
+}
+
+function ensureBalance(accountId, currency) {
+  const state = getState()
+  let balance = state.balances.find(
+    (entry) => entry.accountId === accountId && entry.currency === currency,
+  )
+  if (!balance) {
+    balance = {
+      id: randomUUID(),
+      accountId,
+      currency,
+      available: 0,
+      pending: 0,
+      updatedAt: new Date().toISOString(),
+    }
+    state.balances.push(balance)
+  }
+  return balance
+}
+
+export function createAccount({ name, primaryCurrency = 'USD', metadata = {} }) {
+  if (!name) {
+    throw new Error('Name is required to create an account')
+  }
+  const state = getState()
+  const account = {
+    id: randomUUID(),
+    name,
+    primaryCurrency,
+    metadata,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+  state.accounts.push(account)
+  ensureBalance(account.id, primaryCurrency)
+  recordAuditLog({
+    actorType: ACTOR_TYPES.USER,
+    actionType: ACTION_TYPES.CREATE,
+    objectType: OBJECT_TYPES.ACCOUNT,
+    description: `Account ${account.id} created`,
+    metadata: account,
+  })
+  return account
+}
+
+export function listAccounts() {
+  return [...getState().accounts]
+}
+
+export function getAccountById(id) {
+  return findAccount(id)
+}
+
+export function listBalances(accountId) {
+  const balances = getState().balances
+  if (accountId) {
+    return balances.filter((balance) => balance.accountId === accountId)
+  }
+  return [...balances]
+}
+
+function addLedgerEntry({
+  accountId,
+  currency,
+  amount,
+  type,
+  description,
+  referenceId,
+}) {
+  if (!findAccount(accountId)) {
+    throw new Error('Account not found for ledger entry')
+  }
+  const state = getState()
+  const entry = {
+    id: randomUUID(),
+    accountId,
+    currency,
+    amount,
+    type,
+    description,
+    referenceId,
+    createdAt: new Date().toISOString(),
+  }
+  state.ledgerEntries.push(entry)
+  applyLedgerToBalance(entry)
+  recordAuditLog({
+    actorType: ACTOR_TYPES.SYSTEM,
+    actionType: ACTION_TYPES.CREATE,
+    objectType: OBJECT_TYPES.LEDGER,
+    description,
+    metadata: entry,
+  })
+  return entry
+}
+
+function applyLedgerToBalance(entry) {
+  const balance = ensureBalance(entry.accountId, entry.currency)
+  balance.available += entry.amount
+  balance.updatedAt = new Date().toISOString()
+}
+
+export function listLedgerEntries(accountId) {
+  const entries = getState().ledgerEntries
+  if (accountId) {
+    return entries.filter((entry) => entry.accountId === accountId)
+  }
+  return [...entries]
+}
+
+export function createTransaction({
+  accountId,
+  type,
+  amount,
+  currency = 'USD',
+}) {
+  if (!findAccount(accountId)) {
+    throw new Error('Account not found for transaction')
+  }
+  if (!Object.values(TRANSACTION_TYPES).includes(type)) {
+    throw new Error('Unsupported transaction type')
+  }
+  if (typeof amount !== 'number' || Number.isNaN(amount) || amount <= 0) {
+    throw new Error('Transaction amount must be positive')
+  }
+
+  const state = getState()
+  const transaction = {
+    id: randomUUID(),
+    accountId,
+    type,
+    currency,
+    amount,
+    status: TRANSACTION_STATUSES.PENDING,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+  state.transactions.push(transaction)
+  recordAuditLog({
+    actorType: ACTOR_TYPES.USER,
+    actionType: ACTION_TYPES.CREATE,
+    objectType: OBJECT_TYPES.TRANSACTION,
+    description: `${type} transaction ${transaction.id} created`,
+    metadata: transaction,
+  })
+  return processImmediateTransaction(transaction)
+}
+
+function processImmediateTransaction(transaction) {
+  if (transaction.type === TRANSACTION_TYPES.DEPOSIT) {
+    addLedgerEntry({
+      accountId: transaction.accountId,
+      currency: transaction.currency,
+      amount: transaction.amount,
+      type: LEDGER_ENTRY_TYPES.DEPOSIT,
+      description: `Deposit ${transaction.amount} ${transaction.currency}`,
+      referenceId: transaction.id,
+    })
+    transaction.status = TRANSACTION_STATUSES.COMPLETED
+  } else if (transaction.type === TRANSACTION_TYPES.WITHDRAWAL) {
+    const balance = ensureBalance(transaction.accountId, transaction.currency)
+    if (balance.available < transaction.amount) {
+      transaction.status = TRANSACTION_STATUSES.FAILED
+    } else {
+      addLedgerEntry({
+        accountId: transaction.accountId,
+        currency: transaction.currency,
+        amount: -transaction.amount,
+        type: LEDGER_ENTRY_TYPES.WITHDRAWAL,
+        description: `Withdrawal ${transaction.amount} ${transaction.currency}`,
+        referenceId: transaction.id,
+      })
+      transaction.status = TRANSACTION_STATUSES.COMPLETED
+    }
+  }
+  transaction.updatedAt = new Date().toISOString()
+  recordAuditLog({
+    actorType: ACTOR_TYPES.SYSTEM,
+    actionType: ACTION_TYPES.UPDATE,
+    objectType: OBJECT_TYPES.TRANSACTION,
+    description: `Transaction ${transaction.id} status ${transaction.status}`,
+    metadata: transaction,
+  })
+  return transaction
+}
+
+export function listTransactions(accountId) {
+  const transactions = getState().transactions
+  if (accountId) {
+    return transactions.filter((tx) => tx.accountId === accountId)
+  }
+  return [...transactions]
+}
+
+export function handleTradeSettlement({
+  execution,
+  buyOrder,
+  sellOrder,
+}) {
+  const notional = execution.price * execution.quantity
+  addLedgerEntry({
+    accountId: buyOrder.accountId,
+    currency: buyOrder.currency,
+    amount: -notional,
+    type: LEDGER_ENTRY_TYPES.TRADE_DEBIT,
+    description: `Trade debit for order ${buyOrder.id}`,
+    referenceId: execution.id,
+  })
+  addLedgerEntry({
+    accountId: sellOrder.accountId,
+    currency: sellOrder.currency,
+    amount: notional,
+    type: LEDGER_ENTRY_TYPES.TRADE_CREDIT,
+    description: `Trade credit for order ${sellOrder.id}`,
+    referenceId: execution.id,
+  })
+}
+

--- a/server/services/dataStore.js
+++ b/server/services/dataStore.js
@@ -1,0 +1,120 @@
+import { randomUUID } from 'crypto'
+
+export const ORDER_TYPES = {
+  MARKET: 'MARKET',
+  LIMIT: 'LIMIT',
+}
+
+export const ORDER_SIDES = {
+  BUY: 'BUY',
+  SELL: 'SELL',
+}
+
+export const ORDER_STATUSES = {
+  NEW: 'NEW',
+  PARTIALLY_FILLED: 'PARTIALLY_FILLED',
+  FILLED: 'FILLED',
+  CANCELLED: 'CANCELLED',
+}
+
+export const TIME_IN_FORCE_TYPES = {
+  GTC: 'GTC',
+  IOC: 'IOC',
+}
+
+export const LEDGER_ENTRY_TYPES = {
+  TRADE_DEBIT: 'TRADE_DEBIT',
+  TRADE_CREDIT: 'TRADE_CREDIT',
+  DEPOSIT: 'DEPOSIT',
+  WITHDRAWAL: 'WITHDRAWAL',
+  ADJUSTMENT: 'ADJUSTMENT',
+}
+
+export const TRANSACTION_TYPES = {
+  DEPOSIT: 'DEPOSIT',
+  WITHDRAWAL: 'WITHDRAWAL',
+}
+
+export const TRANSACTION_STATUSES = {
+  PENDING: 'PENDING',
+  COMPLETED: 'COMPLETED',
+  FAILED: 'FAILED',
+}
+
+export const ACTOR_TYPES = {
+  USER: 'USER',
+  SYSTEM: 'SYSTEM',
+}
+
+export const ACTION_TYPES = {
+  CREATE: 'CREATE',
+  UPDATE: 'UPDATE',
+  CANCEL: 'CANCEL',
+  EXECUTE: 'EXECUTE',
+}
+
+export const OBJECT_TYPES = {
+  ORDER: 'ORDER',
+  EXECUTION: 'EXECUTION',
+  POSITION: 'POSITION',
+  ACCOUNT: 'ACCOUNT',
+  LEDGER: 'LEDGER',
+  TRANSACTION: 'TRANSACTION',
+}
+
+const initialState = () => ({
+  orders: [],
+  orderBooks: new Map(),
+  executions: [],
+  positions: new Map(),
+  quotes: new Map(),
+  accounts: [],
+  balances: [],
+  ledgerEntries: [],
+  transactions: [],
+  auditLogs: [],
+})
+
+const state = initialState()
+
+export function getState() {
+  return state
+}
+
+export function resetState() {
+  const fresh = initialState()
+  state.orders = fresh.orders
+  state.orderBooks = fresh.orderBooks
+  state.executions = fresh.executions
+  state.positions = fresh.positions
+  state.quotes = fresh.quotes
+  state.accounts = fresh.accounts
+  state.balances = fresh.balances
+  state.ledgerEntries = fresh.ledgerEntries
+  state.transactions = fresh.transactions
+  state.auditLogs = fresh.auditLogs
+}
+
+export function recordAuditLog({
+  actorType = ACTOR_TYPES.SYSTEM,
+  actionType,
+  objectType,
+  description = '',
+  metadata = {},
+}) {
+  const log = {
+    id: randomUUID(),
+    actorType,
+    actionType,
+    objectType,
+    description,
+    metadata,
+    createdAt: new Date().toISOString(),
+  }
+  state.auditLogs.push(log)
+  return log
+}
+
+export function listAuditLogs() {
+  return [...state.auditLogs]
+}

--- a/server/services/tradingEngine.js
+++ b/server/services/tradingEngine.js
@@ -1,0 +1,348 @@
+import { randomUUID } from 'crypto'
+import {
+  ACTION_TYPES,
+  ACTOR_TYPES,
+  OBJECT_TYPES,
+  ORDER_SIDES,
+  ORDER_STATUSES,
+  ORDER_TYPES,
+  TIME_IN_FORCE_TYPES,
+  getState,
+  recordAuditLog,
+} from './dataStore.js'
+import { handleTradeSettlement } from './accountingEngine.js'
+
+function getBook(instrumentId) {
+  const state = getState()
+  if (!state.orderBooks.has(instrumentId)) {
+    state.orderBooks.set(instrumentId, { buy: [], sell: [] })
+  }
+  return state.orderBooks.get(instrumentId)
+}
+
+function sortBook(book) {
+  const buyPrice = (order) => (order.price ?? Number.POSITIVE_INFINITY)
+  const sellPrice = (order) => (order.price ?? 0)
+  book.buy.sort((a, b) => {
+    const priceDiff = buyPrice(b) - buyPrice(a)
+    if (priceDiff === 0) {
+      return new Date(a.createdAt) - new Date(b.createdAt)
+    }
+    return priceDiff
+  })
+  book.sell.sort((a, b) => {
+    const priceDiff = sellPrice(a) - sellPrice(b)
+    if (priceDiff === 0) {
+      return new Date(a.createdAt) - new Date(b.createdAt)
+    }
+    return priceDiff
+  })
+}
+
+function updateQuotes(instrumentId) {
+  const state = getState()
+  const book = getBook(instrumentId)
+  const bestBid = book.buy[0]?.price ?? null
+  const bestAsk = book.sell[0]?.price ?? null
+  const executions = state.executions.filter(
+    (execution) => execution.instrumentId === instrumentId,
+  )
+  const lastExecution = executions.at(-1)
+  const volume = executions.reduce((sum, execution) => sum + execution.quantity, 0)
+  state.quotes.set(instrumentId, {
+    instrumentId,
+    bid: bestBid,
+    ask: bestAsk,
+    last: lastExecution?.price ?? null,
+    volume,
+    updatedAt: new Date().toISOString(),
+  })
+}
+
+function addOrderToBook(order) {
+  const book = getBook(order.instrumentId)
+  book[order.side.toLowerCase()].push(order)
+  sortBook(book)
+  updateQuotes(order.instrumentId)
+}
+
+function removeOrderFromBook(order) {
+  const book = getBook(order.instrumentId)
+  const sideArray = book[order.side.toLowerCase()]
+  const index = sideArray.findIndex((item) => item.id === order.id)
+  if (index !== -1) {
+    sideArray.splice(index, 1)
+  }
+  updateQuotes(order.instrumentId)
+}
+
+function persistOrder(order) {
+  const state = getState()
+  state.orders.push(order)
+  addOrderToBook(order)
+}
+
+function updateOrderStatus(order, status) {
+  order.status = status
+  order.updatedAt = new Date().toISOString()
+}
+
+function createExecution({ instrumentId, buyOrder, sellOrder, quantity, price }) {
+  const execution = {
+    id: randomUUID(),
+    instrumentId,
+    buyOrderId: buyOrder.id,
+    sellOrderId: sellOrder.id,
+    quantity,
+    price,
+    executedAt: new Date().toISOString(),
+  }
+  const state = getState()
+  state.executions.push(execution)
+  recordAuditLog({
+    actorType: ACTOR_TYPES.SYSTEM,
+    actionType: ACTION_TYPES.EXECUTE,
+    objectType: OBJECT_TYPES.EXECUTION,
+    description: `Execution ${execution.id} created`,
+    metadata: execution,
+  })
+  handleTradeSettlement({ execution, buyOrder, sellOrder })
+  updatePositions({ execution, buyOrder, sellOrder })
+  updateQuotes(instrumentId)
+  return execution
+}
+
+function updatePositions({ execution, buyOrder, sellOrder }) {
+  const state = getState()
+  const buyKey = `${buyOrder.accountId}:${execution.instrumentId}`
+  const sellKey = `${sellOrder.accountId}:${execution.instrumentId}`
+  const buyPosition = state.positions.get(buyKey) ?? {
+    id: randomUUID(),
+    accountId: buyOrder.accountId,
+    instrumentId: execution.instrumentId,
+    quantity: 0,
+    averagePrice: 0,
+    updatedAt: new Date().toISOString(),
+  }
+  const sellPosition = state.positions.get(sellKey) ?? {
+    id: randomUUID(),
+    accountId: sellOrder.accountId,
+    instrumentId: execution.instrumentId,
+    quantity: 0,
+    averagePrice: 0,
+    updatedAt: new Date().toISOString(),
+  }
+
+  // Update buy position average price using weighted average
+  const newQuantity = buyPosition.quantity + execution.quantity
+  buyPosition.averagePrice =
+    newQuantity === 0
+      ? 0
+      :
+          (buyPosition.averagePrice * buyPosition.quantity +
+            execution.price * execution.quantity) /
+          newQuantity
+  buyPosition.quantity = newQuantity
+  buyPosition.updatedAt = new Date().toISOString()
+  state.positions.set(buyKey, buyPosition)
+
+  sellPosition.quantity -= execution.quantity
+  sellPosition.updatedAt = new Date().toISOString()
+  state.positions.set(sellKey, sellPosition)
+
+  recordAuditLog({
+    actorType: ACTOR_TYPES.SYSTEM,
+    actionType: ACTION_TYPES.UPDATE,
+    objectType: OBJECT_TYPES.POSITION,
+    description: 'Positions updated after execution',
+    metadata: {
+      executionId: execution.id,
+      positions: [buyPosition, sellPosition],
+    },
+  })
+}
+
+function processMatches(order) {
+  const book = getBook(order.instrumentId)
+  const isBuy = order.side === ORDER_SIDES.BUY
+  const opposingSide = isBuy ? book.sell : book.buy
+  const executed = []
+
+  const priceComparator = isBuy
+    ? (orderPrice, restingPrice) => orderPrice >= restingPrice
+    : (orderPrice, restingPrice) => orderPrice <= restingPrice
+
+  while (order.remainingQuantity > 0 && opposingSide.length > 0) {
+    const restingOrder = opposingSide[0]
+    const canMatch =
+      order.type === ORDER_TYPES.MARKET ||
+      restingOrder.type === ORDER_TYPES.MARKET ||
+      priceComparator(order.price, restingOrder.price)
+    if (!canMatch) {
+      break
+    }
+    const quantity = Math.min(order.remainingQuantity, restingOrder.remainingQuantity)
+    const price =
+      restingOrder.price ?? order.price ?? 0
+    restingOrder.filledQuantity += quantity
+    restingOrder.remainingQuantity -= quantity
+    if (restingOrder.remainingQuantity === 0) {
+      updateOrderStatus(restingOrder, ORDER_STATUSES.FILLED)
+      removeOrderFromBook(restingOrder)
+    } else {
+      updateOrderStatus(restingOrder, ORDER_STATUSES.PARTIALLY_FILLED)
+    }
+
+    order.filledQuantity += quantity
+    order.remainingQuantity -= quantity
+    updateOrderStatus(
+      order,
+      order.remainingQuantity > 0
+        ? ORDER_STATUSES.PARTIALLY_FILLED
+        : ORDER_STATUSES.FILLED,
+    )
+
+    const execution = createExecution({
+      instrumentId: order.instrumentId,
+      buyOrder: isBuy ? order : restingOrder,
+      sellOrder: isBuy ? restingOrder : order,
+      quantity,
+      price,
+    })
+    executed.push(execution)
+  }
+
+  return executed
+}
+
+export function placeOrder({
+  accountId,
+  instrumentId,
+  side,
+  type = ORDER_TYPES.LIMIT,
+  quantity,
+  price,
+  timeInForce = TIME_IN_FORCE_TYPES.GTC,
+  currency = 'USD',
+}) {
+  if (!accountId || !instrumentId || !side || !quantity) {
+    throw new Error('Missing required order fields')
+  }
+  if (!Object.values(ORDER_SIDES).includes(side)) {
+    throw new Error('Invalid order side')
+  }
+  if (!Object.values(ORDER_TYPES).includes(type)) {
+    throw new Error('Invalid order type')
+  }
+  if (type === ORDER_TYPES.LIMIT && (price === undefined || price === null)) {
+    throw new Error('Limit orders require a price')
+  }
+  if (quantity <= 0) {
+    throw new Error('Quantity must be positive')
+  }
+
+  const now = new Date().toISOString()
+  const order = {
+    id: randomUUID(),
+    accountId,
+    instrumentId,
+    side,
+    type,
+    status: ORDER_STATUSES.NEW,
+    quantity,
+    filledQuantity: 0,
+    remainingQuantity: quantity,
+    price: type === ORDER_TYPES.MARKET ? null : price,
+    timeInForce,
+    currency,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  persistOrder(order)
+  recordAuditLog({
+    actorType: ACTOR_TYPES.USER,
+    actionType: ACTION_TYPES.CREATE,
+    objectType: OBJECT_TYPES.ORDER,
+    description: `Order ${order.id} placed`,
+    metadata: order,
+  })
+
+  const executions = processMatches(order)
+
+  if (
+    order.remainingQuantity > 0 &&
+    (order.type === ORDER_TYPES.MARKET || order.timeInForce === TIME_IN_FORCE_TYPES.IOC)
+  ) {
+    updateOrderStatus(order, ORDER_STATUSES.CANCELLED)
+    removeOrderFromBook(order)
+  }
+
+  if (order.remainingQuantity === 0) {
+    removeOrderFromBook(order)
+  }
+
+  updateQuotes(order.instrumentId)
+
+  return { order, executions }
+}
+
+export function cancelOrder(orderId) {
+  const state = getState()
+  const order = state.orders.find((item) => item.id === orderId)
+  if (!order) {
+    throw new Error('Order not found')
+  }
+  if (order.status === ORDER_STATUSES.FILLED) {
+    throw new Error('Cannot cancel a filled order')
+  }
+  updateOrderStatus(order, ORDER_STATUSES.CANCELLED)
+  removeOrderFromBook(order)
+  recordAuditLog({
+    actorType: ACTOR_TYPES.USER,
+    actionType: ACTION_TYPES.CANCEL,
+    objectType: OBJECT_TYPES.ORDER,
+    description: `Order ${order.id} cancelled`,
+    metadata: order,
+  })
+  return order
+}
+
+export function listOrders() {
+  return [...getState().orders]
+}
+
+export function getOrderById(id) {
+  return getState().orders.find((order) => order.id === id)
+}
+
+export function listExecutions() {
+  return [...getState().executions]
+}
+
+export function listPositions(accountId) {
+  const entries = Array.from(getState().positions.values())
+  if (accountId) {
+    return entries.filter((position) => position.accountId === accountId)
+  }
+  return entries
+}
+
+export function getQuote(instrumentId) {
+  return getState().quotes.get(instrumentId) ?? {
+    instrumentId,
+    bid: null,
+    ask: null,
+    last: null,
+    volume: 0,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+export function listQuotes() {
+  return Array.from(getState().quotes.values())
+}
+
+export function getAuditTrail() {
+  return getState().auditLogs
+}

--- a/server/tests/accountingEngine.test.js
+++ b/server/tests/accountingEngine.test.js
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import {
+  TRANSACTION_STATUSES,
+  TRANSACTION_TYPES,
+  resetState,
+} from '../services/dataStore.js'
+import {
+  createAccount,
+  createTransaction,
+  listBalances,
+  listLedgerEntries,
+  listTransactions,
+} from '../services/accountingEngine.js'
+import { listAuditLogs } from '../services/dataStore.js'
+
+describe('Accounting engine', () => {
+  beforeEach(() => {
+    resetState()
+  })
+
+  it('creates accounts and maintains balances via ledger entries', () => {
+    const account = createAccount({ name: 'Alice' })
+
+    const deposit = createTransaction({
+      accountId: account.id,
+      type: TRANSACTION_TYPES.DEPOSIT,
+      amount: 500,
+    })
+
+    expect(deposit.status).toBe(TRANSACTION_STATUSES.COMPLETED)
+    expect(listBalances(account.id)[0].available).toBeCloseTo(500)
+    expect(listLedgerEntries(account.id)).toHaveLength(1)
+
+    const withdrawal = createTransaction({
+      accountId: account.id,
+      type: TRANSACTION_TYPES.WITHDRAWAL,
+      amount: 200,
+    })
+
+    expect(withdrawal.status).toBe(TRANSACTION_STATUSES.COMPLETED)
+    expect(listBalances(account.id)[0].available).toBeCloseTo(300)
+    expect(listLedgerEntries(account.id)).toHaveLength(2)
+
+    const failedWithdrawal = createTransaction({
+      accountId: account.id,
+      type: TRANSACTION_TYPES.WITHDRAWAL,
+      amount: 1000,
+    })
+
+    expect(failedWithdrawal.status).toBe(TRANSACTION_STATUSES.FAILED)
+    expect(listLedgerEntries(account.id)).toHaveLength(2)
+
+    expect(listTransactions(account.id)).toHaveLength(3)
+    expect(listAuditLogs().length).toBeGreaterThan(0)
+  })
+})

--- a/server/tests/tradingEngine.test.js
+++ b/server/tests/tradingEngine.test.js
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import {
+  ORDER_SIDES,
+  ORDER_TYPES,
+  TRANSACTION_TYPES,
+  resetState,
+} from '../services/dataStore.js'
+import {
+  listExecutions,
+  listPositions,
+  placeOrder,
+} from '../services/tradingEngine.js'
+import {
+  createAccount,
+  createTransaction,
+} from '../services/accountingEngine.js'
+
+const INSTRUMENT_ID = 'AAPL'
+
+describe('Trading engine', () => {
+  beforeEach(() => {
+    resetState()
+  })
+
+  it('matches buy and sell orders and updates positions', () => {
+    const buyer = createAccount({ name: 'Buyer' })
+    const seller = createAccount({ name: 'Seller' })
+
+    createTransaction({
+      accountId: buyer.id,
+      type: TRANSACTION_TYPES.DEPOSIT,
+      amount: 10000,
+    })
+    createTransaction({
+      accountId: seller.id,
+      type: TRANSACTION_TYPES.DEPOSIT,
+      amount: 10000,
+    })
+
+    placeOrder({
+      accountId: seller.id,
+      instrumentId: INSTRUMENT_ID,
+      side: ORDER_SIDES.SELL,
+      type: ORDER_TYPES.LIMIT,
+      quantity: 10,
+      price: 100,
+    })
+
+    const { order: buyOrder, executions } = placeOrder({
+      accountId: buyer.id,
+      instrumentId: INSTRUMENT_ID,
+      side: ORDER_SIDES.BUY,
+      type: ORDER_TYPES.LIMIT,
+      quantity: 10,
+      price: 105,
+    })
+
+    expect(executions).toHaveLength(1)
+    expect(listExecutions()).toHaveLength(1)
+    expect(buyOrder.remainingQuantity).toBe(0)
+
+    const buyerPositions = listPositions(buyer.id)
+    expect(buyerPositions).toHaveLength(1)
+    expect(buyerPositions[0].quantity).toBe(10)
+
+    const sellerPositions = listPositions(seller.id)
+    expect(sellerPositions).toHaveLength(1)
+    expect(sellerPositions[0].quantity).toBe(-10)
+  })
+
+  it('cancels remaining quantity for IOC orders', () => {
+    const buyer = createAccount({ name: 'Buyer-IOC' })
+    const seller = createAccount({ name: 'Seller-IOC' })
+
+    createTransaction({
+      accountId: buyer.id,
+      type: TRANSACTION_TYPES.DEPOSIT,
+      amount: 10000,
+    })
+    createTransaction({
+      accountId: seller.id,
+      type: TRANSACTION_TYPES.DEPOSIT,
+      amount: 10000,
+    })
+
+    placeOrder({
+      accountId: seller.id,
+      instrumentId: INSTRUMENT_ID,
+      side: ORDER_SIDES.SELL,
+      type: ORDER_TYPES.LIMIT,
+      quantity: 5,
+      price: 100,
+    })
+
+    const { order: buyOrder, executions } = placeOrder({
+      accountId: buyer.id,
+      instrumentId: INSTRUMENT_ID,
+      side: ORDER_SIDES.BUY,
+      type: ORDER_TYPES.LIMIT,
+      quantity: 10,
+      price: 100,
+      timeInForce: 'IOC',
+    })
+
+    expect(executions).toHaveLength(1)
+    expect(buyOrder.status).toBe('CANCELLED')
+    expect(buyOrder.remainingQuantity).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- create an in-memory datastore with audit logging helpers and enumerations
- add trading engine logic with REST endpoints for orders, executions, positions, and quotes
- implement accounting engine with account, ledger, balance, and transaction endpoints
- cover trading and accounting lifecycles with Bun-based unit tests

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68e229566f38832aa1b2c480f723b711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added REST APIs for accounts (create/list/get, balances, ledger, transactions, audit logs).
  - Added trading APIs (place/cancel orders, list/get orders, executions, positions, quotes).
  - Introduced a health check endpoint at GET /health.
- Tests
  - Added end-to-end tests covering deposits/withdrawals, balances, ledger entries, audit logs, order matching, IOC handling, executions, and positions.
- Chores
  - Added a test script to run the server test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->